### PR TITLE
support update the segment button widths by manually

### DIFF
--- a/src/components/super-tabs-toolbar.ts
+++ b/src/components/super-tabs-toolbar.ts
@@ -180,7 +180,7 @@ export class SuperTabsToolbar implements AfterViewInit, OnDestroy {
   /**
    * Indexes the segment button widths
    */
-  private indexSegmentButtonWidths() {
+  indexSegmentButtonWidths() {
     let index = [], total = 0;
 
     this.tabButtons.forEach((btn: SuperTabButton, i: number) => {

--- a/src/components/super-tabs.ts
+++ b/src/components/super-tabs.ts
@@ -689,7 +689,13 @@ export class SuperTabs implements OnInit, AfterContentInit, AfterViewInit, OnDes
 
   // needed to make Ionic Framework think this is a tabs component... needed for Deeplinking
   setTabbarPosition() {}
-
+ 
+ // update the segment button widths manually 
+  indexSegmentButtonWidths() {
+    setTimeout(() => {
+      this.toolbar.indexSegmentButtonWidths();
+    }, 1000)
+  }
 }
 
 let superTabsIds = -1;


### PR DESCRIPTION
Fix bug https://github.com/zyra/ionic2-super-tabs/issues/69

### example

**html code**
```html
     <super-tabs id="taskTabs" #SuperTabs *ngIf="segment === 'newTask'" [config]="{ sideMenu: 'left' }" scrollTabs
        toolbarColor="orange" toolbarBackground="white" indicatorColor="orange" badgeColor="yellow" (tabSelect)="onTabSelect($event)">
        <super-tab [swipeBackEnabled]="false" [root]="waitAcceptPage" title="待受理({{newTaskCountObj.distributionWaitAccept}})" status="waitAcceptPage"></super-tab>
        <super-tab [root]="waitAppointmentPage" title="待预约({{newTaskCountObj.waitAppointment}})" status="waitAppointmentPage"></super-tab>
        <super-tab [root]="waitPickupPage" title="待提货({{newTaskCountObj.waitPickUp}})" status="waitPickupPage"></super-tab>
        <super-tab [root]="waitSignPage" title="待签收({{newTaskCountObj.waitSign}})"  status="waitSignPage"></super-tab>
        <super-tab [root]="hadSignPage" title="已签收({{newTaskCountObj.doSign}})" status="hadSignPage"></super-tab>
        <super-tab [root]="cancelledPage" title="已取消({{newTaskCountObj.invalid}})" status="cancelledPage"></super-tab>
        <super-tab [root]="allTaskPage" title="全部({{newTaskCountObj.all}})" status="allTaskPage"></super-tab>
    </super-tabs> 

```

**#SuperTabs**
```ts
@ViewChild(SuperTabs) superTabs: SuperTabs;

```


**update the segment button widths by manually when title change**

```ts

 getAppNodeTypeCount() {
        this.api.noLoading().call('taskInstallController.getAppNodeTypeCount').then(json => {
            let countObj = json && json.result || {};
            Object.assign(this.newTaskCountObj, countObj);
            this.superTabs.indexSegmentButtonWidths(); // update the segment button widths
        }).catch(err => {
        })
    }
```