### PR TITLE
Fix error resize when not show in DOM

### DIFF
--- a/src/components/super-tabs.ts
+++ b/src/components/super-tabs.ts
@@ -353,6 +353,7 @@ export class SuperTabs implements OnInit, AfterContentInit, AfterViewInit, OnDes
   }
 
   resize() {
+    if (this.el.nativeElement.offsetParent === null) return;
     this.setMaxIndicatorPosition();
     this.updateTabWidth();
     this.setFixedIndicatorWidth();


### PR DESCRIPTION
If the Ionic page contains Super tabs inactive and window resize (call the resize function), the Super tabs container will have width:0px