### PR TITLE
fix: Missing super-tabs.scss file

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "copy:scss": "cp src/components/super-tabs.scss dist/components/",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "postchangelog": "git commit -am \"chore(): update changelog\"",
-    "shipit": "npm run build && npm publish"
+    "shipit": "npm run build && run postbuild && npm publish"
   },
   "author": "Ibby Hadeed <ibby@zyra.ca>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "copy:scss": "cp src/components/super-tabs.scss dist/components/",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "postchangelog": "git commit -am \"chore(): update changelog\"",
-    "shipit": "npm run build && run postbuild && npm publish"
+    "shipit": "npm run build && npm run postbuild && npm publish"
   },
   "author": "Ibby Hadeed <ibby@zyra.ca>",
   "license": "MIT",


### PR DESCRIPTION
Copy super-tabs.scss to dist/components directory so that it ends up with the published package.

Inspired by @allanpoppe

https://github.com/allanpoppe/ionic2-super-tabs/commit/b33ffddeed24cddeb756111c051e070bd59c93ab#diff-b9cfc7f2cdf78a7f4b91a753d10865a2