### PR TITLE
Prevent TypeError "Cannot read property 'getActiveChildNavs' of undefined"

### DIFF
--- a/src/components/super-tabs.ts
+++ b/src/components/super-tabs.ts
@@ -441,6 +441,10 @@ export class SuperTabs implements OnInit, AfterContentInit, AfterViewInit, OnDes
   }
 
   getActiveChildNavs(): NavigationContainer[] {
+    if (this.selectedTabIndex < 0) {
+      this.selectedTabIndex = 0;
+    }
+    
     return [this._tabs[this.selectedTabIndex]];
   }
 


### PR DESCRIPTION
This pull request resolves a potential issue in super-tabs when trying to use multiple super-tabs instances in different pages in the same app. The plugin would break with the TypeError in the title, and a re-start would be needed to fix. This now allows the app to continue as normal.