### PR TITLE
Allow restyling height of toolbar

### DIFF
--- a/src/components/super-tabs-toolbar.ts
+++ b/src/components/super-tabs-toolbar.ts
@@ -97,6 +97,13 @@ export class SuperTabsToolbar implements AfterViewInit, OnDestroy {
     private rnd: Renderer2
   ) {}
 
+  get height(): number {
+    if (!this.el || !this.el.nativeElement) {
+      return 0;
+    }
+    return this.el.nativeElement.getBoundingClientRect().height;
+  }
+
   ngAfterViewInit() {
     this.gesture = new SuperTabsPanGesture(
       this.plt,

--- a/src/components/super-tabs.ts
+++ b/src/components/super-tabs.ts
@@ -629,15 +629,7 @@ export class SuperTabsComponent
   }
 
   private refreshContainerHeight() {
-    let heightOffset = 0;
-
-    if (this._isToolbarVisible) {
-      if (this.hasTitles && this.hasIcons) {
-        heightOffset = 72;
-      } else if (this.hasTitles || this.hasIcons) {
-        heightOffset = 48;
-      }
-    }
+    const heightOffset = this._isToolbarVisible ? this.toolbar.height : 0;
 
     this.rnd.setStyle(
       this.tabsContainer.getNativeElement(),


### PR DESCRIPTION
This is basically just a DRY fix - by dynamically getting the height of the toolbar, eliminates need to specify in both CSS and TS. The result is that apps can now change toolbar height using CSS without messing up the tab pane's height.