### PR TITLE
Passthrough lifecycle (depends on PR#352)

### DIFF
--- a/src/components/super-tabs-container.ts
+++ b/src/components/super-tabs-container.ts
@@ -58,6 +58,20 @@ export class SuperTabsContainer implements AfterViewInit, OnDestroy {
   @Output()
   onDrag: EventEmitter<TouchEvent> = new EventEmitter<TouchEvent>();
 
+  /**
+   * Notifies when the container has started being dragged
+   * @type {EventEmitter<TouchEvent>}
+   */
+  @Output()
+  onDragStart: EventEmitter<void> = new EventEmitter<void>();
+
+  /**
+   * Notifies when the container has stopped being dragged
+   * @type {EventEmitter<void>}
+   */
+  @Output()
+  onDragEnd: EventEmitter<void> = new EventEmitter<void>();
+
   // View bindings
 
   /**
@@ -163,6 +177,10 @@ export class SuperTabsContainer implements AfterViewInit, OnDestroy {
 
     this.gesture = new SuperTabsPanGesture(this.plt, this.config, this.container.nativeElement, this.rnd);
 
+    this.gesture.onStart = ()=>{
+      this.onDragStart.emit();
+    }
+
     this.gesture.onMove = (delta: number) => {
       if (this.globalSwipeEnabled === false) return;
       if (this.swipeEnabledPerTab[this.selectedTabIndex] === false) return;
@@ -200,6 +218,7 @@ export class SuperTabsContainer implements AfterViewInit, OnDestroy {
         );
       } else this.setSelectedTab(tabIndex);
 
+      this.onDragEnd.emit();
     };
   }
 

--- a/src/components/super-tabs.ts
+++ b/src/components/super-tabs.ts
@@ -136,6 +136,12 @@ export class SuperTabsComponent
 
   @Input() name: string;
 
+
+  /**
+   * Allow Ionic NavController lifecycle events to pass through to child tabs
+   */
+  @Input() passthroughLifecycle: boolean;
+
   /**
    * Height of the tabs
    */
@@ -293,6 +299,7 @@ export class SuperTabsComponent
 
     if (viewCtrl) {
       obsToMerge.push(viewCtrl.didEnter);
+      // This causes lifecycle events to be passed through to the active tab
     }
 
     // re-adjust the height of the slider when the orientation changes
@@ -338,6 +345,21 @@ export class SuperTabsComponent
         this.getElementRef().nativeElement,
         'tabs-placement-bottom'
       );
+    }
+
+    if(this.passthroughLifecycle && this.viewCtrl) {
+      this.viewCtrl.willEnter.subscribe(() => {
+        this.fireLifecycleEvent(['willEnter']);
+      });
+      this.viewCtrl.didEnter.subscribe(() => {
+        this.fireLifecycleEvent(['didEnter']);
+      });
+      this.viewCtrl.willLeave.subscribe(() => {
+        this.fireLifecycleEvent(['willLeave']);
+      });
+      this.viewCtrl.didLeave.subscribe(() => {
+        this.fireLifecycleEvent(['didLeave']);
+      });
     }
   }
 
@@ -608,22 +630,24 @@ export class SuperTabsComponent
 
   private fireLifecycleEvent(events: string[]) {
     const activeView = this.getActiveTab().getActive();
-    events.forEach((event: string) => {
-      switch (event) {
-        case 'willEnter':
-          activeView._willEnter();
-          break;
-        case 'didEnter':
-          activeView._didEnter();
-          break;
-        case 'willLeave':
-          activeView._willLeave(false);
-          break;
-        case 'didLeave':
-          activeView._didLeave();
-          break;
-      }
-    });
+    if (activeView) {
+      events.forEach((event: string) => {
+        switch (event) {
+          case 'willEnter':
+            activeView._willEnter();
+            break;
+          case 'didEnter':
+            activeView._didEnter();
+            break;
+          case 'willLeave':
+            activeView._willLeave(false);
+            break;
+          case 'didLeave':
+            activeView._didLeave();
+            break;
+        }
+      });  
+    }
   }
 
   private refreshTabStates() {

--- a/src/components/super-tabs.ts
+++ b/src/components/super-tabs.ts
@@ -84,7 +84,7 @@ export interface SuperTabsConfig {
                         [selectedTab]="selectedTabIndex"
                         (tabSelect)="onToolbarTabSelect($event)"></super-tabs-toolbar>
     <super-tabs-container [config]="config" [tabsCount]="_tabs.length" [selectedTabIndex]="selectedTabIndex"
-                          (tabSelect)="onContainerTabSelect($event)" (onDrag)="onDrag()">
+                          (tabSelect)="onContainerTabSelect($event)" (onDrag)="onDrag()" (onDragStart)="tabDragStart.emit()" (onDragEnd)="tabDragEnd.emit()">
       <ng-content></ng-content>
     </super-tabs-container>
   `,
@@ -180,6 +180,18 @@ export class SuperTabsComponent
    * @type {string}
    */
   @Input() tabsPlacement = 'top';
+
+  /**
+   * Emits event when tab dragging is activated
+   */
+  @Output()
+  tabDragStart: EventEmitter<void> = new EventEmitter<void>();
+
+  /**
+   * Emits event when tab dragging is stopped (when a user lets go)
+   */
+  @Output()
+  tabDragEnd: EventEmitter<void> = new EventEmitter<void>();
 
   /**
    * Emits the tab index when the selected tab changes
@@ -753,6 +765,14 @@ export class SuperTabsComponent
         animate
       );
     }
+  }
+
+  private tabDragStarted() {
+    this.tabDragStart.emit();
+  }
+
+  private tabDragStopped() {
+    this.tabDragEnd.emit();
   }
 
   getTabIndexById(tabId: string): number {

--- a/src/super-tabs-pan-gesture.ts
+++ b/src/super-tabs-pan-gesture.ts
@@ -5,6 +5,8 @@ import { pointerCoord, PointerCoordinates } from 'ionic-angular/util/dom';
 import { SuperTabsConfig } from './components/super-tabs';
 
 export class SuperTabsPanGesture {
+  onStart: () => void;
+
   onMove: (delta: number) => void;
 
   onEnd: (shortSwipe: boolean, shortSwipeDelta?: number) => void;
@@ -98,6 +100,9 @@ export class SuperTabsPanGesture {
       if (this.shouldCapture === true) {
         // gesture is good, let's capture all next onTouchMove events
         this.isDragging = true;
+
+        // emit value
+        this.onStart && this.onStart();
       } else {
         return;
       }


### PR DESCRIPTION
This PR exposes the option to pass-through lifecycle events to child tabs via ViewController when the SuperTabs component experiences them. 

Allows you to trigger ionViewDidEnter, etc, when the page containing the SuperTabs component is entered (otherwise the active tab has no idea it is now visible and should be, for example, refreshed -- of ChangeDetector is detached, or etc.)

Depends on: https://github.com/zyra/ionic2-super-tabs/pull/352